### PR TITLE
fix: résoudre les erreurs de compilation

### DIFF
--- a/server/scheduler-service.ts
+++ b/server/scheduler-service.ts
@@ -383,5 +383,3 @@ export class SchedulerService {
     };
   }
 }
-
-export { SchedulerService };

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -395,11 +395,7 @@ export class DatabaseStorage implements IStorage {
       .where(eq(passwordResetTokens.id, id));
   }
 
-  async cleanupExpiredTokens(): Promise<void> {
-    await db
-      .delete(passwordResetTokens)
-      .where(sql`expires_at < NOW()`);
-  }
+
 
   // Participant Change Requests
   async createParticipantChangeRequest(request: InsertParticipantChangeRequest): Promise<ParticipantChangeRequest> {

--- a/server/stripe-service.ts
+++ b/server/stripe-service.ts
@@ -412,4 +412,4 @@ export class StripeService {
   }
 }
 
-export { stripe, StripeService };
+export { stripe };

--- a/server/subscription-service.ts
+++ b/server/subscription-service.ts
@@ -493,5 +493,3 @@ export class SubscriptionService {
     }
   }
 }
-
-export { SubscriptionService };


### PR DESCRIPTION
- Supprimer les exports en double dans les services
- Supprimer la méthode cleanupExpiredTokens dupliquée
- Garder uniquement la version avec paramètre cutoffDate
- La compilation du serveur fonctionne correctement