### PR TITLE
fix: replace obsolete stripe redirecttocheckout with direct session url

### DIFF
--- a/client/src/components/subscription/PaymentSetup.tsx
+++ b/client/src/components/subscription/PaymentSetup.tsx
@@ -175,19 +175,25 @@ export default function PaymentSetup({ isOpen, onClose, onSuccess, targetPlan }:
         }),
       });
 
-      const { sessionId, error } = await response.json();
+      const data = await response.json();
       
-      if (error) {
-        throw new Error(error);
+      if (data.error) {
+        throw new Error(data.error);
       }
 
-      // Rediriger vers Stripe Checkout
-      const { error: stripeError } = await stripe.redirectToCheckout({
-        sessionId: sessionId,
-      });
-
-      if (stripeError) {
-        throw new Error(stripeError.message);
+      // Rediriger vers l'URL de checkout Stripe moderne
+      if (data.url) {
+        window.location.href = data.url;
+      } else if (data.sessionId) {
+        // Fallback: utiliser l'ancienne méthode si l'URL n'est pas disponible
+        const { error: stripeError } = await stripe.redirectToCheckout({
+          sessionId: data.sessionId,
+        });
+        if (stripeError) {
+          throw new Error(stripeError.message);
+        }
+      } else {
+        throw new Error("Aucune URL de redirection fournie");
       }
     } catch (error: any) {
       console.error('Erreur de paiement:', error);

--- a/client/src/components/subscription/SubscriptionCheckout.tsx
+++ b/client/src/components/subscription/SubscriptionCheckout.tsx
@@ -130,15 +130,17 @@ export function SubscriptionCheckout({ plans, currentPlan, onPlanSelect, loading
         throw new Error(errorData.message || 'Erreur lors de la création de la session de paiement');
       }
 
-      const { sessionId, url } = await response.json();
+      const data = await response.json();
       
-      if (url) {
-        // Rediriger vers Stripe Checkout
-        window.location.href = url;
-      } else if (sessionId) {
-        // Utiliser le checkout intégré
-        setClientSecret(sessionId);
+      if (data.url) {
+        // Rediriger vers l'URL de checkout Stripe moderne
+        window.location.href = data.url;
+      } else if (data.sessionId) {
+        // Utiliser le checkout intégré avec le sessionId
+        setClientSecret(data.sessionId);
         setCheckoutMode('payment');
+      } else {
+        throw new Error("Aucune URL de redirection ou session ID fournie");
       }
       
     } catch (error: any) {

--- a/server/stripe-service.ts
+++ b/server/stripe-service.ts
@@ -84,7 +84,10 @@ export class StripeService {
 
       const session = await stripe.checkout.sessions.create(sessionConfig);
 
-      return { id: session.id };
+      return { 
+        id: session.id,
+        url: session.url 
+      };
     } catch (error: any) {
       console.error('Erreur création session Stripe:', error);
       throw new Error(`Erreur Stripe: ${error.message}`);

--- a/server/subscription-service.ts
+++ b/server/subscription-service.ts
@@ -108,7 +108,11 @@ export class SubscriptionService {
       },
     });
 
-    return { sessionId: session.id, mode: 'payment' };
+    return { 
+      sessionId: session.id, 
+      url: session.url,
+      mode: 'payment' 
+    };
   }
 
   // Créer un abonnement Pro
@@ -140,7 +144,11 @@ export class SubscriptionService {
       },
     });
 
-    return { sessionId: session.id, mode: 'subscription' };
+    return { 
+      sessionId: session.id, 
+      url: session.url,
+      mode: 'subscription' 
+    };
   }
 
   // Gérer la confirmation de paiement

--- a/test-stripe-integration.html
+++ b/test-stripe-integration.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Stripe Integration</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .product {
+            text-align: center;
+            margin-bottom: 30px;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+        }
+        .product img {
+            max-width: 200px;
+            height: auto;
+            margin-bottom: 15px;
+        }
+        .product h3 {
+            color: #333;
+            margin: 10px 0;
+        }
+        .product .price {
+            font-size: 24px;
+            font-weight: bold;
+            color: #007cba;
+        }
+        .checkout-btn {
+            background: #6772e5;
+            color: white;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            cursor: pointer;
+            margin: 10px 5px;
+            transition: background-color 0.2s;
+        }
+        .checkout-btn:hover {
+            background: #5469d4;
+        }
+        .checkout-btn:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .message {
+            color: #666;
+            font-size: 16px;
+            line-height: 1.4;
+        }
+        .success { color: #28a745; }
+        .error { color: #dc3545; }
+        .loading { color: #007bff; }
+        .security-info {
+            background: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            padding: 15px;
+            margin-top: 20px;
+            font-size: 14px;
+            color: #6c757d;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🎾 Test d'Intégration Stripe - TeamMove</h1>
+        
+        <div id="product-display">
+            <div class="product">
+                <img src="https://images.unsplash.com/photo-1554068666-08edca2d1e8e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80" alt="TeamMove - Covoiturage Sportif" />
+                <div class="description">
+                    <h3>Pack Événement TeamMove</h3>
+                    <div class="price">15,00€</div>
+                    <p>Un événement sportif avec covoiturage organisé</p>
+                </div>
+            </div>
+            
+            <form action="/api/create-checkout-session-test" method="POST">
+                <button type="submit" class="checkout-btn" id="checkout-btn">
+                    💳 Procéder au paiement
+                </button>
+            </form>
+            
+            <button class="checkout-btn" onclick="testStripeConfig()">
+                🔧 Tester la configuration Stripe
+            </button>
+            
+            <button class="checkout-btn" onclick="testSubscriptionPlans()">
+                📋 Voir les plans d'abonnement
+            </button>
+        </div>
+
+        <div id="message" style="display: none;">
+            <p class="message"></p>
+        </div>
+
+        <div class="security-info">
+            <strong>🔒 Paiement 100% sécurisé</strong><br>
+            • Cryptage SSL et protocoles de sécurité Stripe<br>
+            • Aucune donnée de carte bancaire stockée sur nos serveurs<br>
+            • Mode test activé - utilisez les cartes de test Stripe
+        </div>
+    </div>
+
+    <script>
+        // Fonction pour tester la configuration Stripe
+        async function testStripeConfig() {
+            showMessage('Vérification de la configuration Stripe...', 'loading');
+            
+            try {
+                const response = await fetch('/api/stripe/config');
+                const data = await response.json();
+                
+                if (data.valid) {
+                    showMessage(`✅ Configuration Stripe valide (Mode: ${data.mode})`, 'success');
+                } else {
+                    showMessage(`❌ Configuration Stripe invalide: ${data.issues?.join(', ') || 'Erreur inconnue'}`, 'error');
+                }
+            } catch (error) {
+                showMessage(`❌ Erreur lors de la vérification: ${error.message}`, 'error');
+            }
+        }
+
+        // Fonction pour tester les plans d'abonnement
+        async function testSubscriptionPlans() {
+            showMessage('Chargement des plans d\'abonnement...', 'loading');
+            
+            try {
+                const response = await fetch('/api/subscription/plans');
+                const data = await response.json();
+                
+                if (data.plans) {
+                    const planCount = Object.keys(data.plans).length;
+                    showMessage(`✅ ${planCount} plans d'abonnement disponibles`, 'success');
+                    console.log('Plans:', data.plans);
+                } else {
+                    showMessage('❌ Aucun plan d\'abonnement trouvé', 'error');
+                }
+            } catch (error) {
+                showMessage(`❌ Erreur lors du chargement des plans: ${error.message}`, 'error');
+            }
+        }
+
+        // Fonction utilitaire pour afficher les messages
+        function showMessage(text, type = '') {
+            const messageDiv = document.getElementById('message');
+            const messageText = messageDiv.querySelector('.message');
+            
+            messageText.textContent = text;
+            messageText.className = `message ${type}`;
+            messageDiv.style.display = 'block';
+            
+            // Masquer automatiquement après 5 secondes sauf pour les erreurs
+            if (type !== 'error') {
+                setTimeout(() => {
+                    messageDiv.style.display = 'none';
+                }, 5000);
+            }
+        }
+
+        // Vérifier les paramètres URL pour les messages de retour
+        window.addEventListener('load', function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            
+            if (urlParams.get('success')) {
+                showMessage('✅ Commande réussie ! Vous recevrez un email de confirmation.', 'success');
+            }
+
+            if (urlParams.get('canceled')) {
+                showMessage('❌ Commande annulée -- continuez à explorer et finalisez quand vous êtes prêt.', 'error');
+            }
+        });
+
+        // Désactiver le bouton pendant le traitement
+        document.getElementById('checkout-btn').addEventListener('click', function() {
+            this.disabled = true;
+            this.textContent = '⏳ Redirection...';
+            
+            // Réactiver le bouton après 5 secondes en cas de problème
+            setTimeout(() => {
+                this.disabled = false;
+                this.textContent = '💳 Procéder au paiement';
+            }, 5000);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- update paymentsetup.tsx and subscriptioncheckout.tsx
- modify stripe-service.ts to return session.url
- add test routes for integration verification
- create html test page for stripe payments

fixes error: stripe.redirecttocheckout is no longer supported
preserve: email, profile, events, invitations, support features