### PR TITLE
fix(stripe): correct missing stripe-service module imports

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2748,7 +2748,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // ========== SUBSCRIPTION & BILLING ROUTES (MODERNIZED) ==========
   // Import new subscription services (SubscriptionService already imported and initialized at startup)
-  const { StripeService } = await import('./stripe-service');
+  const { StripeServiceNew } = await import('./stripe-service-new');
   const { EmailService } = await import('./email-service');
   const { SchedulerService } = await import('./scheduler-service');
   const { SUBSCRIPTION_PLANS, NEW_SUBSCRIPTION_LIMITS } = await import('./subscription-config');


### PR DESCRIPTION
- Fixed import in subscription-service.ts to use stripe-service-new instead of missing stripe-service
- Updated API calls to match StripeServiceNew interface
- Fixed createEventPackagePayment to use correct method signature
- Fixed createProSubscription to use correct method signature
- Fixed cancelSubscription to use organizationId parameter
- Corrected import in routes.ts to use StripeServiceNew
- Application now starts without ERR_MODULE_NOT_FOUND errors
- All existing functionalities preserved